### PR TITLE
Fix collection title color

### DIFF
--- a/src/collect.js
+++ b/src/collect.js
@@ -1086,7 +1086,7 @@ window.MediathreadCollect = {
 
                     title.focus();
                     title.css({
-                        color: '#999',
+                        color: '#000',
                         width: '350px',
                         height: '35px',
                         fontSize: '14px',


### PR DESCRIPTION
This changes the title color in the 'collect' pop-up from gray to black, because the gray text looks like a placeholder.