### PR TITLE
Fix video metadata collection - PMT #102984

### DIFF
--- a/css/sherd_styles.css
+++ b/css/sherd_styles.css
@@ -6,6 +6,10 @@
     left: 0;
     background: url(/img/overlaybg.png) repeat;
 }
+.sherd-analyzer button,
+.sherd-analyzer input[type="button"] {
+    cursor: pointer;
+}
 .sherd-window-inner h2{
     color: #fff;
     font-size: 14px;

--- a/src/asset-handler.js
+++ b/src/asset-handler.js
@@ -740,10 +740,10 @@ var assetHandler = {
                 if (video.canPlayType(video.type) === 'probably') {
                     rv.primary_type = vid_type;
                 }
-            } else if (mtype == String(source.src).match(codecs)) {
+            } else if (mtype === String(source.src).match(codecs)) {
                 vid_type = mtype[1].toLowerCase().replace('ogv', 'ogg');
             }
-            if (rv.primary_type == 'video') {
+            if (rv.primary_type === 'video') {
                 rv.primary_type = vid_type;
             }
             rv.sources[vid_type] = source.src;

--- a/src/collect.js
+++ b/src/collect.js
@@ -254,7 +254,9 @@ window.MediathreadCollect = {
         return img;
     },
     'mergeMetadata': function(result, metadata) {
-        if (!metadata) return;
+        if (!metadata) {
+            return;
+        }
         if (!result.metadata) {
             result.metadata = metadata;
             return result.metadata;
@@ -320,7 +322,9 @@ window.MediathreadCollect = {
                     case 'img':
                     case 'source':
                     case 'video':
-                        props[p].push(abs(this.src, doc));
+                        if (this.src) {
+                            props[p].push(abs(this.src, doc));
+                        }
                         break;
                     default:
                         props[p].push($(this).text());


### PR DESCRIPTION
This collects the schema.org metadata for video tags
as well as images. For some reason, the data is only being
pulled into Mediathread on my local instance - the
fall.midterm.2015 branch, not production.

Tested on Zarina's video test page:
https://pmt.ccnmtl.columbia.edu/item/102984/#event-5