### PR TITLE
Don't strip url params - PMT #103693

### DIFF
--- a/src/collect.js
+++ b/src/collect.js
@@ -925,7 +925,6 @@ window.MediathreadCollect = {
         this.displayAsset = function(asset,index) {
             var assetUrl = asset.sources[asset.primary_type];
             if (typeof assetUrl !== 'undefined') {
-                // make sure to strip out any url params
                 asset.sources[asset.primary_type] = assetUrl;
             }
             if (!asset) {

--- a/src/collect.js
+++ b/src/collect.js
@@ -926,7 +926,7 @@ window.MediathreadCollect = {
             var assetUrl = asset.sources[asset.primary_type];
             if (typeof assetUrl !== 'undefined') {
                 // make sure to strip out any url params
-                asset.sources[asset.primary_type] = assetUrl.split('?')[0];
+                asset.sources[asset.primary_type] = assetUrl;
             }
             if (!asset) {
                 return;


### PR DESCRIPTION
On digitalcollections.nypl.org, the image src's are
PHP scripts that require url params in order to display
correctly.