### PR TITLE
Make host url configurable - PMT #104364

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
     "preset": "google",
-    "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
-    "validateIndentation": 4
+    "validateIndentation": 4,
+    "disallowTrailingWhitespace": true,
+    "requireCamelCaseOrUpperCaseIdentifiers": false
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
   - "5"
 script:
+  - make jshint
+  - make jscs
   - make test

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ test: node_modules
 	npm test
 
 jshint: node_modules/jshint/bin/jshint
-	./node_modules/jshint/bin/jshint src/*.js src/**/*.js tests/*.js
+	npm run-script jshint
 
 jscs: node_modules/jscs/bin/jscs
-	./node_modules/jscs/bin/jscs src/*.js src/**/*.js tests/*.js
+	npm run-script jscs
 
 node_modules:
 	npm install

--- a/manifest.json
+++ b/manifest.json
@@ -19,8 +19,13 @@
         "128": "img/icon-128.png"
     },
     "permissions": [
-        "activeTab"
+        "activeTab",
+        "storage"
     ],
     "version": "0.8.5",
-    "manifest_version": 2
+    "manifest_version": 2,
+    "options_ui": {
+        "page": "options.html",
+        "chrome_style": true
+    }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Mediathread Options</title>
+    </head>
+    <body>
+        <h3>Mediathread URL</h3>
+        <div>
+            <select id="host_url" name="host_url">
+                <option value="https://mediathread.ccnmtl.columbia.edu/">
+                    https://mediathread.ccnmtl.columbia.edu/
+                </option>
+                <option value="https://mediathread.qa.ccnmtl.columbia.edu/">
+                    https://mediathread.qa.ccnmtl.columbia.edu/
+                </option>
+                <option value="https://mediathread.stage.ccnmtl.columbia.edu/">
+                    https://mediathread.stage.ccnmtl.columbia.edu/
+                </option>
+            </select>
+            <p>
+                The Mediathread URL can be changed for testing purposes. For
+                normal use, leave this set to
+                https://mediathread.ccnmtl.columbia.edu/.
+            </p>
+        </div>
+
+        <script src="src/options.js"></script>
+    </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "mocha": "^2.3.3"
   },
   "scripts": {
-    "pretest": "jshint src/*.js tests/*.js && jscs src/*.js tests/*.js",
+    "jshint": "jshint src/*.js tests/*.js",
+    "jscs": "jscs src/*.js tests/*.js",
     "test": "mocha tests/ -t 20000"
   },
   "repository": {

--- a/src/background.js
+++ b/src/background.js
@@ -3,7 +3,6 @@ chrome.browserAction.onClicked.addListener(function(tab) {
     chrome.tabs.executeScript(tab.id, {file: 'lib/URI.js'});
     chrome.tabs.executeScript(tab.id, {file: 'src/loadcss.js'});
     chrome.tabs.executeScript(tab.id, {file: 'src/collect-popup.js'});
-    chrome.tabs.executeScript(tab.id, {file: 'src/common/settings.js'});
     chrome.tabs.executeScript(tab.id, {file: 'src/common/host-handler.js'});
     chrome.tabs.executeScript(tab.id, {file: 'src/common/asset-handler.js'});
     chrome.tabs.executeScript(tab.id, {file: 'src/common/collect.js'});

--- a/src/common/collect.js
+++ b/src/common/collect.js
@@ -1,5 +1,5 @@
 window.MediathreadCollect = {
-    /* updated by /accounts/logged_in.js */
+    /* updated by /accounts/is_logged_in/ */
     'user_status': {
         ready: false
     },
@@ -8,10 +8,10 @@ window.MediathreadCollect = {
         return true;
     },
     update_user_status: function(userStatus) {
-        var uninit = !window.MediathreadCollect.user_status.ready;
         for (var a in userStatus) {
             window.MediathreadCollect.user_status[a] = userStatus[a];
         }
+
         if (window.console) {
             window.console.log(userStatus);
         }
@@ -24,12 +24,6 @@ window.MediathreadCollect = {
         if ('flickr_apikey' in userStatus) {
             window.MediathreadCollect.options.flickr_apikey =
                 userStatus.flickr_apikey;
-        }
-
-        //Safari sometimes loads logged_in.js last, even when added first
-        if (uninit && userStatus.ready && MediathreadCollect.g) {
-            //find assets again
-            MediathreadCollect.g.findAssets();
         }
     },
     'hosthandler': hostHandler,
@@ -50,7 +44,12 @@ window.MediathreadCollect = {
         if (!obj.sources.url) {
             obj.sources.url = String(document.location);
         }
-        var destination =  host_url;
+
+        if (!/\/save\/$/.test(host_url)) {
+            host_url += '/save/';
+        }
+
+        var destination = host_url;
         for (var a in obj.sources) {
             if (typeof obj.sources[a] === 'undefined') {
                 continue;
@@ -73,7 +72,10 @@ window.MediathreadCollect = {
                 (index ? '#' + obj.sources[obj.primary_type]
                  .split('#')[0].split('/').pop() : '');
         }
-        var destination =  host_url;
+        if (!/\/save\/$/.test(host_url)) {
+            host_url += '/save/';
+        }
+        var destination = host_url;
         if (obj.hash) {
             destination += '#' + obj.hash;
         }
@@ -164,6 +166,9 @@ window.MediathreadCollect = {
     },
     'runners': {
         jump: function(host_url, jump_now) {
+            if (!/\/save\/$/.test(host_url)) {
+                host_url += '/save/';
+            }
             var final_url = host_url;
             var M = MediathreadCollect;
             var handler = M.gethosthandler();
@@ -204,6 +209,9 @@ window.MediathreadCollect = {
             handler.find.call(handler, jump_with_first_asset);
         },
         decorate: function(host_url) {
+            if (!/\/save\/$/.test(host_url)) {
+                host_url += '/save/';
+            }
             var M = MediathreadCollect;
             function go(run_func) {
                 M.g = new M.Interface(host_url);
@@ -719,6 +727,9 @@ window.MediathreadCollect = {
      END Finder
       *****************/
     'Interface': function(host_url, options) {
+        if (!/\/save\/$/.test(host_url)) {
+            host_url += '/save/';
+        }
         var M = MediathreadCollect;
         this.options = {
             login_url: null,
@@ -745,7 +756,7 @@ window.MediathreadCollect = {
                 this.options[a] = options[a];
             }
         }
-        //bring in options from MediathreadCollectOptions
+        //bring in options from MediathreadCollect.options
         for (var b in this.options) {
             if (M.options[b]) {
                 this.options[b] = M.options[b];
@@ -886,7 +897,7 @@ window.MediathreadCollect = {
 
             M.connect(comp.tab, 'click', this.onclick);
             M.connect(comp.collection, 'click', function(evt) {
-                var hostURL = MediathreadCollectOptions.host_url;
+                var hostURL = MediathreadCollect.options.host_url;
                 var url = me.unHttpsTheLink(hostURL.split(/\/save\//)[0]);
                 window.location.replace(url + '/asset/');
             });
@@ -963,8 +974,7 @@ window.MediathreadCollect = {
                 });
                 $(form.firstChild).empty().append(newAsset);
             } else {
-                asset.sources.thumb =
-                    host_url.split('save')[0] + 'media/img/nothumb_video.png';
+                asset.sources.thumb = host_url + 'media/img/nothumb_video.png';
                 newAsset =
                     me.elt(null, 'img', 'sherd-video', {
                         src: asset.sources.thumb,
@@ -1137,16 +1147,12 @@ window.MediathreadCollect = {
     }
 };/*MediathreadCollect (root)*/
 
-if (!window.MediathreadCollectOptions) {
-    window.MediathreadCollectOptions = {};
-}
-
 ///1. search for assets--as soon as we find one, break out and send show: true
 ///2. on request, return a full asset list
 ///3. allow the grabber to be created by sending an asset list to it
-MediathreadCollect.options = MediathreadCollectOptions;
+MediathreadCollect.options = {};
 
-if (MediathreadCollectOptions.user_status) {
+if (MediathreadCollect.options.user_status) {
     MediathreadCollect.update_user_status(
-        MediathreadCollectOptions.user_status);
+        MediathreadCollect.options.user_status);
 }

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -1,6 +1,0 @@
-var MediathreadCollectOptions = {
-    cross_origin: true,
-    host_url: 'https://mediathread.ccnmtl.columbia.edu/save/',
-    user_url: 'https://mediathread.ccnmtl.columbia.edu/' +
-        'accounts/is_logged_in/'
-};

--- a/src/init.js
+++ b/src/init.js
@@ -1,37 +1,54 @@
-$.ajax({
-    url: MediathreadCollectOptions.user_url,
-    dataType: 'json',
-    crossDomain: true,
-    cache: false,
-    xhrFields: {
-        withCredentials: true
-    },
-    success: function(d) {
-        var hostUrl = MediathreadCollectOptions.host_url.replace(
-                /\/save\/$/, '');
-        if ('flickr_apikey' in d) {
-            MediathreadCollect.options.flickr_apikey = d.flickr_apikey;
+/**
+ * Returns a promise yielding the host url stored in the extension's
+ * settings.
+ */
+var getHostUrl = function() {
+    return new Promise(function(fulfill, reject) {
+        try {
+            chrome.storage.sync.get('options', function(data) {
+                fulfill(data.options.hostUrl);
+            });
+        } catch (e) {
+            // If anything fails, just return the default hardcoded
+            // host url.
+            fulfill('https://mediathread.ccnmtl.columbia.edu/');
         }
-        if ('youtube_apikey' in d) {
-            MediathreadCollect.options.youtube_apikey = d.youtube_apikey;
-        }
+    });
+};
 
-        if (d.logged_in === true && d.course_selected === true) {
-            // Start the main plugin code
-            MediathreadCollect.runners.jump(
-                MediathreadCollectOptions.host_url, true);
-        } else if (d.logged_in === true && d.course_selected === false) {
-            alert(
-                'You\'re logged in to Mediathread at ' +
-                    hostUrl +
-                    ', now select a course to use the Chrome extension.');
-        } else {
-            alert(
-                'Log in to Mediathread here: ' + hostUrl +
-                    ' and select a course!');
+getHostUrl().then(function(hostUrl) {
+    $.ajax({
+        url: hostUrl + '/accounts/is_logged_in/',
+        dataType: 'json',
+        crossDomain: true,
+        cache: false,
+        xhrFields: {
+            withCredentials: true
+        },
+        success: function(d) {
+            if ('flickr_apikey' in d) {
+                MediathreadCollect.options.flickr_apikey = d.flickr_apikey;
+            }
+            if ('youtube_apikey' in d) {
+                MediathreadCollect.options.youtube_apikey = d.youtube_apikey;
+            }
+
+            if (d.logged_in === true && d.course_selected === true) {
+                // Start the main plugin code
+                MediathreadCollect.runners.jump(hostUrl, true);
+            } else if (d.logged_in === true && d.course_selected === false) {
+                alert(
+                    'You\'re logged in to Mediathread at ' +
+                        hostUrl +
+                        ', now select a course to use the Chrome extension.');
+            } else {
+                alert(
+                    'Log in to Mediathread at ' + hostUrl +
+                        ' and select a course!');
+            }
+        },
+        error: function(d) {
+            console.error('ajax error in init.js', d);
         }
-    },
-    error: function(d) {
-        console.error('#', d);
-    }
+    });
 });

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,28 @@
+// Restores select box state using the preferences
+// stored in chrome.storage.
+function loadOptions() {
+    chrome.storage.sync.get('options', function(data) {
+        var options = data.options;
+
+        if (!options.hostUrl) {
+            var defaultHost = 'https://mediathread.ccnmtl.columbia.edu/';
+            options.hostUrl = defaultHost;
+        }
+
+        document.getElementById('host_url').value = options.hostUrl;
+    });
+}
+
+// Saves options to chrome.storage.
+function storeOptions() {
+    var hostUrl = document.getElementById('host_url').value;
+    chrome.storage.sync.set({
+        options: {
+            hostUrl: hostUrl
+        }
+    }, function optionsSaved() {
+    });
+}
+
+document.addEventListener('DOMContentLoaded', loadOptions);
+document.getElementById('host_url').addEventListener('change', storeOptions);


### PR DESCRIPTION
The mediathread instance that the extension points to can now
be chosen with a dropdown menu in the extension's options.

For now, to make the UI simple, I'm just providing three pre-determined
choices for the mediathread url: production, staging, and qa.

I've done some refactoring here, removing settings.js since
it's not really necessary.

There's a bunch of changes to the common code that I will merge
into the rest of the repositories.