### PR TITLE
remove /save/ from host url when necessary

### DIFF
--- a/src/common/collect.js
+++ b/src/common/collect.js
@@ -974,7 +974,9 @@ window.MediathreadCollect = {
                 });
                 $(form.firstChild).empty().append(newAsset);
             } else {
-                asset.sources.thumb = host_url + 'media/img/nothumb_video.png';
+                asset.sources.thumb =
+                    host_url.replace(/save\/$/, '') +
+                    'media/img/nothumb_video.png';
                 newAsset =
                     me.elt(null, 'img', 'sherd-video', {
                         src: asset.sources.thumb,


### PR DESCRIPTION
host_url now refers to the plain mediathread URL, without `/save/` at
the end. Most of the code here still relies on having `/save/` at the
end of the url, but not all of it. That caused some confusion here.

I promise myself to clean up this bad code at some point. I am just
taking this one step at a time.