### PR TITLE
Fix Vimeo collection bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-01-21  Nik Nyby  <nnyby@columbia.edu>
+
+	* Fix Vimeo asset collection bug.
+
 2016-01-12  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix bug that occurs with host url when options aren't present.

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
         "activeTab",
         "storage"
     ],
-    "version": "0.8.7",
+    "version": "0.8.8",
     "manifest_version": 2,
     "options_ui": {
         "page": "options.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediathread-chrome",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Find assets to analyze in Mediathread.",
   "main": "background.js",
   "directories": {

--- a/src/common/host-handler.js
+++ b/src/common/host-handler.js
@@ -644,11 +644,11 @@ var hostHandler = {
                 var $wrapper = $(videos[0]);
                 var $player = $wrapper.closest('.player');
                 var url = $player.data('fallback-url');
-                var vimeoId = $player.data('clip-id');
+                var vimeoId = $player.data('clip-id') || $player.attr('id');
 
                 MediathreadCollect.assethandler.objects_and_embeds
                     .players.moogaloop.asset(
-                        video,
+                        $('.video-wrapper video').first(),
                         vimeoId,
                         {
                             'window': window,


### PR DESCRIPTION
Vimeo needs to collect on Vimeo's asset page, e.g. both these pages
should work with the extension:
* https://vimeo.com/152150724
* https://vimeo.com/channels/staffpicks/152150724

Releasing a new extension version since this is preventing people from
using Vimeo with the extension.