### PR TITLE
Make host_url completely configurable - PMT #105269

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-02-16  Nik Nyby  <nnyby@columbia.edu>
+
+	* Host URL can now be set to anything in the
+	extension options.
+
 2016-01-21  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix Vimeo asset collection bug.

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
         "activeTab",
         "storage"
     ],
-    "version": "0.8.8",
+    "version": "0.9.0",
     "manifest_version": 2,
     "options_ui": {
         "page": "options.html",

--- a/options.html
+++ b/options.html
@@ -2,28 +2,67 @@
 <html>
     <head>
         <title>Mediathread Options</title>
+        <style>
+        .hidden {
+            display: none;
+        }
+
+        .radio label {
+            width: 100%;
+        }
+
+        form input[type="radio"] {
+            margin-right: 5px;
+        }
+
+        form input[type="text"] {
+            margin-left: 5px;
+            width: 75%;
+        }
+        </style>
     </head>
     <body>
         <h3>Mediathread URL</h3>
-        <div>
-            <select id="host_url" name="host_url">
-                <option value="https://mediathread.ccnmtl.columbia.edu/">
-                    https://mediathread.ccnmtl.columbia.edu/
-                </option>
-                <option value="https://mediathread.qa.ccnmtl.columbia.edu/">
-                    https://mediathread.qa.ccnmtl.columbia.edu/
-                </option>
-                <option value="https://mediathread.stage.ccnmtl.columbia.edu/">
-                    https://mediathread.stage.ccnmtl.columbia.edu/
-                </option>
-            </select>
-            <p>
-                The Mediathread URL can be changed for testing purposes. For
-                normal use, leave this set to
-                https://mediathread.ccnmtl.columbia.edu/.
-            </p>
-        </div>
+        <form>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="host_url" id="host_url_prod"
+                           value="https://mediathread.ccnmtl.columbia.edu" checked>
+                    https://mediathread.ccnmtl.columbia.edu
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="host_url" id="host_url_qa"
+                           value="https://mediathread.qa.ccnmtl.columbia.edu">
+                    https://mediathread.qa.ccnmtl.columbia.edu
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="host_url" id="host_url_stage"
+                           value="https://mediathread.stage.ccnmtl.columbia.edu">
+                    https://mediathread.stage.ccnmtl.columbia.edu
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="host_url" id="host_url_custom"
+                           value="other">
+                    Other: <input name="custom_url"
+                                  type="text"
+                                  value=""
+                                  disabled
+                                  autocomplete="off"
+                                  autocapitalize="off"
+                                  autocorrect="off"
+                                  spellcheck="false" />
+                </label>
+            </div>
+        </form>
+        <div id="infospace" class="hidden">Saved.</div>
 
+        <script src="lib/jquery-2.2.0.min.js"></script>
         <script src="src/options.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediathread-chrome",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "Find assets to analyze in Mediathread.",
   "main": "background.js",
   "directories": {

--- a/src/init.js
+++ b/src/init.js
@@ -8,7 +8,11 @@ var getHostUrl = function() {
         try {
             chrome.storage.sync.get('options', function(data) {
                 if (data.options) {
-                    fulfill(data.options.hostUrl);
+                    if (data.options.hostUrl === 'other') {
+                        fulfill(data.options.customUrl);
+                    } else {
+                        fulfill(data.options.hostUrl);
+                    }
                 } else {
                     fulfill(defaultHostUrl);
                 }
@@ -22,8 +26,9 @@ var getHostUrl = function() {
 };
 
 getHostUrl().then(function(hostUrl) {
+    var isLoggedInUrl = hostUrl + '/accounts/is_logged_in/';
     $.ajax({
-        url: hostUrl + '/accounts/is_logged_in/',
+        url: isLoggedInUrl,
         dataType: 'json',
         crossDomain: true,
         cache: false,
@@ -53,7 +58,7 @@ getHostUrl().then(function(hostUrl) {
             }
         },
         error: function(d) {
-            console.error('ajax error in init.js', d);
+            alert('Error loading URL: ' + isLoggedInUrl);
         }
     });
 });

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,9 @@
+var prefilledUrls = [
+    'https://mediathread.ccnmtl.columbia.edu',
+    'https://mediathread.qa.ccnmtl.columbia.edu',
+    'https://mediathread.stage.ccnmtl.columbia.edu'
+];
+
 // Restores select box state using the preferences
 // stored in chrome.storage.
 function loadOptions() {
@@ -5,24 +11,64 @@ function loadOptions() {
         var options = data.options;
 
         if (!options.hostUrl) {
-            var defaultHost = 'https://mediathread.ccnmtl.columbia.edu/';
+            var defaultHost = prefilledUrls[0];
             options.hostUrl = defaultHost;
         }
 
-        document.getElementById('host_url').value = options.hostUrl;
-    });
-}
-
-// Saves options to chrome.storage.
-function storeOptions() {
-    var hostUrl = document.getElementById('host_url').value;
-    chrome.storage.sync.set({
-        options: {
-            hostUrl: hostUrl
+        if (!options.customUrl) {
+            options.customUrl = '';
         }
-    }, function optionsSaved() {
+
+        // Select the appropriate radio button
+        switch (options.hostUrl) {
+        case prefilledUrls[0]:
+            $('#host_url_prod').prop('checked', true);
+            break;
+        case prefilledUrls[1]:
+            $('#host_url_qa').prop('checked', true);
+            break;
+        case prefilledUrls[2]:
+            $('#host_url_stage').prop('checked', true);
+            break;
+        case 'other':
+            $('#host_url_custom').prop('checked', true);
+            $('input[name="custom_url"]').prop('disabled', false);
+            break;
+        default:
+            $('#host_url_prod').prop('checked', true);
+            break;
+        }
+
+        $('input[name="custom_url"]').val(options.customUrl);
     });
 }
 
 document.addEventListener('DOMContentLoaded', loadOptions);
-document.getElementById('host_url').addEventListener('change', storeOptions);
+
+// Saves options to chrome.storage.
+function storeOptions(hostUrl, customUrl) {
+    $('#infospace').hide();
+
+    if (hostUrl === 'other') {
+        $('input[name="custom_url"]').prop('disabled', false);
+    } else {
+        $('input[name="custom_url"]').prop('disabled', true);
+    }
+
+    chrome.storage.sync.set({
+        options: {
+            hostUrl: hostUrl,
+            customUrl: customUrl
+        }
+    }, function optionsSaved() {
+        $('#infospace').fadeIn();
+    });
+}
+
+$('input[name="custom_url"]').on('change keyup', function() {
+    storeOptions('other', this.value);
+});
+
+$('input[type="radio"][name="host_url"]').change(function() {
+    storeOptions(this.value, $('input[name="custom_url"]').val());
+});

--- a/src/options.js
+++ b/src/options.js
@@ -58,7 +58,7 @@ function storeOptions(hostUrl, customUrl) {
     chrome.storage.sync.set({
         options: {
             hostUrl: hostUrl,
-            customUrl: customUrl
+            customUrl: $.trim(customUrl)
         }
     }, function optionsSaved() {
         $('#infospace').fadeIn();


### PR DESCRIPTION
This changes the URL options to a radio button interface with an "Other"
field to enter a custom URL.

I've added an alert message that pops up if the is_logged_in ajax request
fails. This will let users know why the URL fails when entering a custom
url, and will help us debug any problems.

I've also incremented the version to 0.9.0 so I can make a new release.

![2016-02-17-114433_413x252_scrot](https://cloud.githubusercontent.com/assets/59292/13117233/071f4ad8-d56d-11e5-9342-cf983be333e9.png)
