### PR TITLE
Settings update fixes - PMT #109909

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-02-23  Nik Nyby  <nnyby@columbia.edu>
+
+	* Send an error when attempting to update the extension over HTTP.
+	* Add *.dartmouth.edu to externally connectable whitelist.
+
 2017-02-13  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fixed image collection on blakearchive.org.

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
     "externally_connectable": {
         "matches": [
             "*://*.columbia.edu/*",
+            "*://*.dartmouth.edu/*",
             "*://localhost:*/*"
         ]
     },

--- a/src/background.js
+++ b/src/background.js
@@ -4,11 +4,13 @@ var getPathFromUrl = function(url) {
 
 chrome.runtime.onMessageExternal.addListener(
     function(request, sender, sendResponse) {
-        if (
-            request.command &&
-                request.command === 'updatesettings' &&
-                sender.url.startsWith('https://')
-        ) {
+        if (request.command && request.command === 'updatesettings') {
+            if (!sender.url.startsWith('https://')) {
+                sendResponse('This extension requires Mediathread to be ' +
+                             'used over HTTPS.');
+                return false;
+            }
+
             var url = sender.url;
             url = getPathFromUrl(url);
             url = url.replace(/\/$/, '');


### PR DESCRIPTION
Two things were causing this error:
* Needed to whitelist *.dartmouth.edu as a connectable URL from the
  extension.
* Added error messaging to show that Mediathread needs to be used over
  HTTPS. The extension can't be used over HTTP because that causes CORS
  errors when making the request to `/accounts/is_logged_in/`.