### PR TITLE
Fix duplicate slash error when loading auth state from Mediathread

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-11-29  Nik Nyby  <nnyby@columbia.edu>
+
+	* Fix duplicate slash error when loading auth state from
+	Mediathread.
+
 2018-11-27  Nik Nyby  <nnyby@columbia.edu>
 
 	* Update jQuery to 3.3.1

--- a/src/init.js
+++ b/src/init.js
@@ -29,9 +29,10 @@ var getHostUrl = function() {
 };
 
 getHostUrl().then(function(hostUrl) {
-    var isLoggedInUrl = hostUrl + '/accounts/is_logged_in/';
+    // Creating this URL object properly removes duplicate slashes.
+    var isLoggedInUrl = new URL('/accounts/is_logged_in/', hostUrl);
     $.ajax({
-        url: isLoggedInUrl,
+        url: isLoggedInUrl.href,
         dataType: 'json',
         crossDomain: true,
         cache: false,
@@ -61,7 +62,7 @@ getHostUrl().then(function(hostUrl) {
             }
         },
         error: function() {
-            alert('Error loading URL: ' + isLoggedInUrl);
+            alert('Error loading URL: ' + isLoggedInUrl.href);
         }
     });
 });


### PR DESCRIPTION
This error seems to have only started happening lately, otherwise we
would have ran into it sooner.

This may address #118, we'll see. When the extension is installed, the
hostUrl is set to `https://mediathread.ccnmtl.columbia.edu/`, with a
trailing slash, causing the request to break when the extension is used,
until the user sets the URL to the one without the trailing slash. This
change will fix that.