### PR TITLE
Fix more duplicate slash errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-12-03  Nik Nyby  <nnyby@columbia.edu>
+
+	* Fix more duplicate slash errors in other parts of the code by
+	using a proper URL parser.
+
 2018-11-29  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix duplicate slash error when loading auth state from

--- a/src/collect-popup.js
+++ b/src/collect-popup.js
@@ -64,13 +64,14 @@ var collectPopupClickHandler = function(form, me, $buttonAsset, hostUrl) {
                 .width() / 2) - (535 * 0.5);
         var alertSavedMarginTop =
             ($(window).height() / 2) - 100;
-        var collectionUrl = hostUrl.replace(/\/save\/$/, '') + '/asset/';
+        var collectionUrl = new URL(
+            '/asset/', hostUrl.replace(/\/save\/$/, ''));
         var alertSaved = $(
             '<div class="alert-saved">' +
                 '<span style="font-weight:bold">' +
                 'Success.</span> Your item has been ' +
                 'successfully added to your ' +
-                '<a href="' + collectionUrl +
+                '<a href="' + collectionUrl.href +
                 '">Mediathread collection</a>.</div>');
         var alertClose = $(
             '<div class="alert-close">X</div>');

--- a/src/common/collect.js
+++ b/src/common/collect.js
@@ -53,7 +53,7 @@ window.MediathreadCollect = {
                     .split('#')[0].split('/').pop() : '');
         }
         if (!/\/save\/$/.test(host_url)) {
-            host_url += '/save/';
+            host_url = new URL('/save/', host_url).href;
         }
         var destination = host_url;
         if (obj.hash) {
@@ -173,7 +173,7 @@ window.MediathreadCollect = {
     'runners': {
         jump: function(host_url) {
             if (!/\/save\/$/.test(host_url)) {
-                host_url += '/save/';
+                host_url = new URL('/save/', host_url).href;
             }
             var M = MediathreadCollect;
             var handler = M.gethosthandler();
@@ -215,7 +215,7 @@ window.MediathreadCollect = {
         },
         decorate: function(host_url) {
             if (!/\/save\/$/.test(host_url)) {
-                host_url += '/save/';
+                host_url = new URL('/save/', host_url).href;
             }
             var M = MediathreadCollect;
             function go(run_func) {
@@ -515,7 +515,7 @@ window.MediathreadCollect = {
 
 var Interface = function(host_url, options) {
     if (!/\/save\/$/.test(host_url)) {
-        host_url += '/save/';
+        host_url = new URL('/save/', host_url).href;
     }
 
     this.host_url = host_url;
@@ -654,7 +654,7 @@ Interface.prototype.setupContent = function(target) {
 
     var hostUrl = this.host_url;
     hostUrl = hostUrl.replace(/\/save\/$/, '');
-    var collectionUrl = hostUrl + '/asset/';
+    var collectionUrl = new URL('/asset/', hostUrl).href;
 
     this.components.top.appendChild(
         this.elt(doc, 'div', 'sherd-tab', '', [this.options.tab_label]));


### PR DESCRIPTION
Using a proper URL parser to avoid making URLs with multiple slashes
when pointing to Mediathread's `/asset/` and `/save/` routes.