### PR TITLE
Update Mediathread URL to use *.ctl

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-10-31  Nik Nyby  <nnyby@columbia.edu>
+
+	* Update Mediathread url to use *.ctl
+	* Remove mediathread.qa url option
+
 2019-03-27  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix a CORB request problem that was introduced in Chrome 73.

--- a/options.html
+++ b/options.html
@@ -27,22 +27,15 @@
             <div class="radio">
                 <label>
                     <input type="radio" name="host_url" id="host_url_prod"
-                           value="https://mediathread.ccnmtl.columbia.edu" checked>
-                    https://mediathread.ccnmtl.columbia.edu
-                </label>
-            </div>
-            <div class="radio">
-                <label>
-                    <input type="radio" name="host_url" id="host_url_qa"
-                           value="https://mediathread.qa.ccnmtl.columbia.edu">
-                    https://mediathread.qa.ccnmtl.columbia.edu
+                           value="https://mediathread.ctl.columbia.edu" checked>
+                    https://mediathread.ctl.columbia.edu
                 </label>
             </div>
             <div class="radio">
                 <label>
                     <input type="radio" name="host_url" id="host_url_stage"
-                           value="https://mediathread.stage.ccnmtl.columbia.edu">
-                    https://mediathread.stage.ccnmtl.columbia.edu
+                           value="https://mediathread.stage.ctl.columbia.edu">
+                    https://mediathread.stage.ctl.columbia.edu
                 </label>
             </div>
             <div class="radio">

--- a/src/init.js
+++ b/src/init.js
@@ -7,7 +7,7 @@
  */
 var getHostUrl = function() {
     return new Promise(function(fulfill) {
-        var defaultHostUrl = 'https://mediathread.ccnmtl.columbia.edu/';
+        var defaultHostUrl = 'https://mediathread.ctl.columbia.edu/';
         try {
             chrome.storage.sync.get('options', function(data) {
                 if (data.options) {

--- a/src/options.js
+++ b/src/options.js
@@ -2,9 +2,8 @@
 /* global chrome, _ */
 
 var prefilledUrls = [
-    'https://mediathread.ccnmtl.columbia.edu',
-    'https://mediathread.qa.ccnmtl.columbia.edu',
-    'https://mediathread.stage.ccnmtl.columbia.edu'
+    'https://mediathread.ctl.columbia.edu',
+    'https://mediathread.stage.ctl.columbia.edu'
 ];
 
 // Restores select box state using the preferences


### PR DESCRIPTION
These routes are active now.

Also, remove the unused mediathread.qa URL.