### PR TITLE
Fix Artstor collection - closes #140

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2019-11-01  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix CORB error when collecting YouTube videos
+	* Fix Artstor asset collection
 
 2019-10-31  Nik Nyby  <nnyby@columbia.edu>
 

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
             "*://localhost:*/*"
         ]
     },
-    "version": "0.9.15",
+    "version": "0.9.16",
     "manifest_version": 2,
     "options_ui": {
         "page": "options.html",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mediathread-chrome",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediathread-chrome",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Find assets to analyze in Mediathread.",
   "main": "background.js",
   "directories": {

--- a/src/common/host-handler.js
+++ b/src/common/host-handler.js
@@ -184,9 +184,10 @@ var hostHandler = {
                     success: function(metadata) {
                         obj.sources.title = metadata.title;
                         obj.sources.thumb =
-                            'https://library.artstor.org' +
-                            metadata.imageUrl;
-                        var m = metadata.metaData;
+                            'https://library.artstor.org' + (
+                                metadata.imageUrl || metadata.image_url);
+
+                        var m = metadata.metaData || metadata.metadata_json;
                         for (var i = 0; i < m.length; i++) {
                             ///so multiple values are still OK
                             if (m[i].fieldName in obj.metadata) {


### PR DESCRIPTION
This fixes the Sentry error:

> Asset creation failed with request data: ..etc.

The thumbnail image is still not coming through (artstor is now using
time-sensitive authed AWS URLs for image thumbnails), but at least the
import happens correctly.