### PR TITLE
Don't include CORS credentials in YouTube request

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-05-22  Nik Nyby  <nnyby@columbia.edu>
+
+	* Don't include CORS credentials in YouTube request.
+
 2019-11-01  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix CORB error when collecting YouTube videos

--- a/src/background.js
+++ b/src/background.js
@@ -31,8 +31,7 @@ chrome.runtime.onMessage.addListener(
 
             fetch(url, {
                 cache: 'no-cache',
-                mode: 'cors',
-                credentials: 'include'
+                mode: 'cors'
             })
                 .then(response => response.json())
                 .then(data => {


### PR DESCRIPTION
This fixes the following error:

  Request has been blocked by CORS policy: The value of
  the 'Access-Control-Allow-Credentials' header in the
  response is '' which must be 'true' when the request's
  credentials mode is 'include'.