### PR TITLE
Fix setting custom URL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-08-05  Nik Nyby  <nnyby@columbia.edu>
+
+	* Fix setting custom URL name: use only hostname
+
 2020-05-22  Nik Nyby  <nnyby@columbia.edu>
 
 	* Don't include CORS credentials in YouTube request.

--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,5 @@
 /* globals chrome, $ */
 
-var getPathFromUrl = function(url) {
-    return url.split(/[?#]/)[0];
-};
-
 // https://www.chromium.org/Home/chromium-security/extension-content-script-fetches
 chrome.runtime.onMessage.addListener(
     function(request, sender, sendResponse) {
@@ -54,13 +50,11 @@ chrome.runtime.onMessageExternal.addListener(
                 return false;
             }
 
-            var url = sender.url;
-            url = getPathFromUrl(url);
-            url = url.replace(/\/$/, '');
+            var url = new URL(sender.url);
             chrome.storage.sync.set({
                 options: {
                     hostUrl: 'other',
-                    customUrl: url
+                    customUrl: url.origin
                 }
             }, function optionsSaved() {
                 sendResponse('Mediathread URL updated to: ' + url);


### PR DESCRIPTION
The custom URL was getting set to the entire URL, hostname +
`/course/1/collection/add/`, in Mediathread. This will fix that.