### PR TITLE
Fix "new URL" message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-08-12  Nik Nyby  <nnyby@columbia.edu>
+
+	* Fix "new URL" message
+
 2020-08-06  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix Vimeo video collection

--- a/src/background.js
+++ b/src/background.js
@@ -51,13 +51,14 @@ chrome.runtime.onMessageExternal.addListener(
             }
 
             var url = new URL(sender.url);
+            var newUrl = url.origin;
             chrome.storage.sync.set({
                 options: {
                     hostUrl: 'other',
-                    customUrl: url.origin
+                    customUrl: newUrl
                 }
             }, function optionsSaved() {
-                sendResponse('Mediathread URL updated to: ' + url);
+                sendResponse('Mediathread URL updated to: ' + newUrl);
             });
         }
         return true;


### PR DESCRIPTION
The URL's origin was getting set correctly (the URL without the path),
but the message was still giving the full URL. This will fix that.