### PR TITLE
Fix Flickr collection problem - MEDT-3716

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-08-18  Nik Nyby  <nnyby@columbia.edu>
+
+	* Instead of doing $form.submit(), make an XHR request 
+	to avoid 'form-action' CSP restrictions. This fixes a media
+	collection problem with Flickr.
+
 2020-08-12  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fix "new URL" message

--- a/src/collect-popup.js
+++ b/src/collect-popup.js
@@ -58,42 +58,60 @@ var collectPopupClickHandler = function(form, me, $buttonAsset, hostUrl) {
         });
 
     $('#submit-input', bucketWindow.document).click(function() {
-        $(this).closest('form').submit();
-        var sherdOverlay = $('.sherd-window-inner', window.document);
-        var alertSavedMarginLeft =
-            ($('.sherd-window-inner', window.document)
-                .width() / 2) - (535 * 0.5);
-        var alertSavedMarginTop =
-            ($(window).height() / 2) - 100;
-        var collectionUrl = new URL(
-            '/asset/', hostUrl.replace(/\/save\/$/, ''));
-        var alertSaved = $(
-            '<div class="alert-saved">' +
-                '<span style="font-weight:bold">' +
-                'Success.</span> Your item has been ' +
-                'successfully added to your ' +
-                '<a href="' + collectionUrl.href +
-                '">Mediathread collection</a>.</div>');
-        var alertClose = $(
-            '<div class="alert-close">X</div>');
+        var $form = $(this).closest('form');
+        var action = $form.attr('action');
 
-        alertSaved.css({
-            'top': alertSavedMarginTop + 'px',
-            'left': alertSavedMarginLeft + 'px'
-        });
-        alertClose.click(function() {
-            $(this).parent().remove();
-        });
-        alertSaved.prepend(alertClose);
-        sherdOverlay.append(alertSaved);
-        alertSaved.fadeIn(500, function() {
-            var btn = $buttonAsset;
-            btn.attr('value', 'Collected');
-            btn.off();
-            btn.css({
-                background: '#999',
-                color: '#333'
-            });
+        // Instead of doing $form.submit(), make an XHR request 
+        // to avoid 'form-action' CSP restrictions.
+        $.ajax(action, {
+            method: 'POST',
+            data: $form.serialize(),
+            xhrFields: {
+                withCredentials: true
+            },
+            success: function() {
+                bucketWindow.close();
+
+                var sherdOverlay = $('.sherd-window-inner', window.document);
+                var alertSavedMarginLeft =
+                    ($('.sherd-window-inner', window.document)
+                        .width() / 2) - (535 * 0.5);
+                var alertSavedMarginTop =
+                    ($(window).height() / 2) - 100;
+                var collectionUrl = new URL(
+                    '/asset/', hostUrl.replace(/\/save\/$/, ''));
+                var alertSaved = $(
+                    '<div class="alert-saved">' +
+                        '<span style="font-weight:bold">' +
+                        'Success.</span> Your item has been ' +
+                        'successfully added to your ' +
+                        '<a href="' + collectionUrl.href +
+                        '">Mediathread collection</a>.</div>');
+                var alertClose = $(
+                    '<div class="alert-close">X</div>');
+
+                alertSaved.css({
+                    'top': alertSavedMarginTop + 'px',
+                    'left': alertSavedMarginLeft + 'px'
+                });
+                alertClose.click(function() {
+                    $(this).parent().remove();
+                });
+                alertSaved.prepend(alertClose);
+                sherdOverlay.append(alertSaved);
+                alertSaved.fadeIn(500, function() {
+                    var btn = $buttonAsset;
+                    btn.attr('value', 'Collected');
+                    btn.off();
+                    btn.css({
+                        background: '#999',
+                        color: '#333'
+                    });
+                });
+            },
+            error: function(e) {
+                console.error('Mediathread extension collection error:', e);
+            }
         });
     });// end #submit-input' click
 


### PR DESCRIPTION
Flickr has added:

    form-action https://*.flickr.com https://*.flickrpro.com;

to the end of their content-security-policy. This prevents the
extension's form submit action in the popup window from working.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action

Fortunately, I can just mock the form submit with an XHR request, and
this works in all the cases I've tested.